### PR TITLE
Rescue from Net::OpenTimeout when connecting

### DIFF
--- a/lib/agent/connection.rb
+++ b/lib/agent/connection.rb
@@ -7,7 +7,7 @@ require "json"
 module OasAgent
   module Agent
     class Connection
-      CONNECTION_ERRORS = [Net::HTTPRequestTimeOut, Net::HTTPGatewayTimeOut, Net::ReadTimeout, EOFError, SystemCallError, SocketError].freeze
+      CONNECTION_ERRORS = [Net::HTTPRequestTimeOut, Net::HTTPGatewayTimeOut, Net::OpenTimeout, Net::ReadTimeout, EOFError, SystemCallError, SocketError].freeze
 
       def initialize
         @default_headers = {


### PR DESCRIPTION
This has been observed as a failure when the agent is trying to make a connection and fails to open the connection, from both CI and dev machines. Add it to the existing rescue mechanism for connection setup.

```
An error occurred while loading spec_helper.
Failure/Error: require File.expand_path("../config/environment", __dir__)

Net::OpenTimeout:
  Failed to open TCP connection to ownandship.io:443 (execution expired)
# ./config/initializers/read_only_db.rb:3:in `<main>'
# ./config/environment.rb:7:in `<top (required)>'
# ./spec/rails_helper.rb:6:in `<top (required)>'
# ./spec/spec_helper.rb:5:in `<top (required)>'
No examples found.
```

Fixes #1 