### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/lint_ruby.yml
+++ b/.github/workflows/lint_ruby.yml
@@ -1,0 +1,25 @@
+name: Lint Ruby
+
+on:
+  push:
+    # Sequence of patterns matched against refs/heads
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  rubocop:
+    name: RuboCop
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - uses: reviewdog/action-rubocop@v2
+        with:
+          fail_on_error: true
+          reporter: github-pr-review
+          rubocop_version: gemfile
+          skip_install: true
+          use_bundler: true

--- a/.github/workflows/test_ruby.yml
+++ b/.github/workflows/test_ruby.yml
@@ -14,7 +14,8 @@ jobs:
       RAILS_ENV: test
     strategy:
       matrix:
-        ruby: ["1.9.3", "2.0", "2.1", "2.2", "2.3", "2.4", "2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "head"]
+        # We need to add "1.9.3", "2.0", "2.1", "2.2", "2.3", "2.4" at some point.
+        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "head"]
     steps:
       - name: Clone project
         uses: actions/checkout@v3

--- a/.github/workflows/test_ruby.yml
+++ b/.github/workflows/test_ruby.yml
@@ -1,0 +1,28 @@
+name: Ruby tests
+
+on:
+  push:
+    # Sequence of patterns matched against refs/heads
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      RAILS_ENV: test
+    strategy:
+      matrix:
+        ruby: ["1.9.3", "2.0", "2.1", "2.2", "2.3", "2.4", "2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "head"]
+    steps:
+      - name: Clone project
+        uses: actions/checkout@v3
+      - name: rm Gemfile.lock
+        run: rm Gemfile.lock
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: false
+      - run: bundle --jobs 8 --retry 3
+      - run: bundle exec rake test

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,80 @@
+AllCops:
+  DisabledByDefault: true
+
+Bundler:
+  Enabled: true
+
+Layout/TrailingEmptyLines:
+  Enabled: true
+
+Layout/IndentationStyle:
+  IndentationWidth: 2
+  Enabled: true
+  EnforcedStyle: spaces
+
+Layout/TrailingWhitespace:
+  Enabled: true
+
+Layout/SpaceBeforeComment:
+  Enabled: true
+
+Layout/SpaceBeforeFirstArg:
+  Enabled: true
+
+Layout/BlockEndNewline:
+  Enabled: true
+
+Layout/ClosingHeredocIndentation:
+  Enabled: true
+
+# This tries to force two tabs on a comment, there isn't a config option to make
+# it a single tab
+Layout/CommentIndentation:
+  Enabled: false
+
+Layout/DefEndAlignment:
+  Enabled: true
+
+Layout/EmptyLineAfterMagicComment:
+  Enabled: true
+
+Layout/EmptyLinesAroundArguments:
+  Enabled: true
+
+Layout/EndOfLine:
+  EnforcedStyle: lf
+  Enabled: true
+
+Layout/IndentationConsistency:
+  Enabled: true
+
+Layout/InitialIndentation:
+  Enabled: true
+
+Layout/LeadingCommentSpace:
+  Enabled: true
+
+Layout/RescueEnsureAlignment:
+  Enabled: true
+
+Layout/SpaceAfterMethodName:
+  Enabled: true
+
+Layout/SpaceAfterNot:
+  Enabled: true
+
+Layout/SpaceAfterSemicolon:
+  Enabled: true
+
+Layout/SpaceAroundKeyword:
+  Enabled: true
+
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+
+Style/NestedTernaryOperator:
+  Enabled: true
+
+Style/StringLiterals:
+  Enabled: true
+  EnforcedStyle: double_quotes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,8 +6,35 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    ast (2.4.2)
+    json (2.6.3)
+    language_server-protocol (3.17.0.3)
     minitest (5.13.0)
-    rake (10.5.0)
+    msgpack (1.6.0)
+    parallel (1.23.0)
+    parser (3.2.2.4)
+      ast (~> 2.4.1)
+      racc
+    racc (1.7.3)
+    rainbow (3.1.1)
+    rake (13.1.0)
+    regexp_parser (2.8.2)
+    rexml (3.2.6)
+    rubocop (1.57.2)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.2.2.4)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.28.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.30.0)
+      parser (>= 3.2.1.0)
+    ruby-progressbar (1.13.0)
+    unicode-display_width (2.5.0)
 
 PLATFORMS
   ruby
@@ -15,8 +42,10 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 2.0)
   minitest (~> 5.0)
+  msgpack (~> 1.6.0)
   oas_agent!
-  rake (~> 10.0)
+  rake
+  rubocop
 
 BUNDLED WITH
-   2.0.2
+   2.4.6

--- a/oas_agent.gemspec
+++ b/oas_agent.gemspec
@@ -29,7 +29,8 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "msgpack", "~> 1.6.0"
 
+  spec.add_development_dependency "rubocop"
   spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest", "~> 5.0"
 end


### PR DESCRIPTION
Run CI! Tests multiple Rubies. I've excluded 2.4 and below as these aren't working yet and require some work, but I'd like to expand support backwards to 1.9.3 if possible. This may require some work to work around older versions of some gems. I'm pushing another branch later that will help diagnose the issues with earlier rubies later.

Upgrading Rake as v10 breaks on more modern Rubies:

> NoMethodError: undefined method `=~' for #<Proc:0x000000010ddeebe0 /Users/will/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rake-10.5.0/lib/rake/application.rb:393 (lambda)>
