### PR TITLE
Run tests locally for ancient ruby versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 /pkg/
 /spec/reports/
 /tmp/
+docker-build-ruby*log
+docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+ARG RUBY_VERSION
+FROM ruby:$RUBY_VERSION
+
+# No docs, they slow us down and we don't need them.
+RUN { \
+      echo 'install: --no-document'; \
+      echo 'update: --no-document'; \
+    } >> /etc/gemrc
+
+WORKDIR /usr/src/app
+COPY . .
+
+# Install bundler version compatible with older Ruby versions and install gems
+RUN if ruby -e 'exit RUBY_VERSION < "2.6"'; then \
+        gem install bundler -v '<= 2.3.26'; \
+    else \
+        gem install bundler -v "$(tail -n1 Gemfile.lock | tr -d ' ')"; \
+    fi
+RUN bundle
+
+CMD ["bundle", "exec", "rake"]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,14 @@ GEM
     ast (2.4.2)
     json (2.6.3)
     language_server-protocol (3.17.0.3)
+    mini_portile2 (2.6.1)
     minitest (5.13.0)
     msgpack (1.6.0)
+    nokogiri (1.12.5)
+      mini_portile2 (~> 2.6.1)
+      racc (~> 1.4)
+    nokogiri (1.12.5-x86_64-darwin)
+      racc (~> 1.4)
     parallel (1.23.0)
     parser (3.2.2.4)
       ast (~> 2.4.1)
@@ -38,11 +44,13 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-darwin-22
 
 DEPENDENCIES
   bundler (~> 2.0)
   minitest (~> 5.0)
   msgpack (~> 1.6.0)
+  nokogiri (~> 1.12.0)
   oas_agent!
   rake
   rubocop

--- a/README.md
+++ b/README.md
@@ -52,6 +52,42 @@ After checking out the repo, run `bin/setup` to install dependencies. Then, run 
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
+### Testing ye olde Ruby versions in Docker
+
+You can test old versions of Ruby locally as long as you have Docker installed. To test all versions this library supports you can run:
+
+    rake test:all
+
+You will get an output something like this:
+
+    Ruby 2.3.8 ❌ failed, run this version using `rake "test:one[2.3.8]"`
+    Ruby 1.9.3 ❌ failed, run this version using `rake "test:one[1.9.3]"`
+    Ruby 2.2.10 ❌ failed, run this version using `rake "test:one[2.2.10]"`
+    Ruby 2.4.10 ❌ failed, run this version using `rake "test:one[2.4.10]"`
+    Ruby 3.0: ✅ passed
+    Ruby 3.1: ✅ passed
+    Ruby 2.7.5: ✅ passed
+    Ruby 3.2: ✅ passed
+    Ruby 3.3-rc: ✅ passed
+    Ruby 2.6: ✅ passed
+    Ruby 2.5.9: ✅ passed
+    Ruby 2.1.10 ❌ failed, run this version using `rake "test:one[2.1.10]"`
+    Ruby 2.0 ❌ failed, run this version using `rake "test:one[2.0]"`
+
+Where a version fails you will be given a command to run the tests for that specific version:
+
+    rake "test:one[2.4.10]"
+    or…
+    VERSION=2.4.10 rake test:one
+
+This will give you the test suite output too so you can see what failed. If you need to diagnose Docker/build issues then pass VERBOSE to get the docker build output:
+
+    VERBOSE=1 rake "test:one[2.4.10]"
+
+If you need to further diagnose Docker build issues you can build a docker image for the version you're interested in directly:
+
+    docker build . --build-arg RUBY_VERSION=2.4.10
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/wjessop/oas_ruby_agent.

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,105 @@
 require "bundler/gem_tasks"
 require "rake/testtask"
+require "yaml"
 
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"
   t.libs << "lib"
   t.test_files = FileList["test/**/*_test.rb"]
 end
+
+# Helper method to normalize Ruby version strings for service names
+def normalize_version(version)
+  version.gsub(".", "_").gsub("-", "_")
+end
+
+# Helper method to run docker-compose and capture the output, including build logs
+def docker_compose_up(service_name)
+  # Directing build output to a file
+  build_log_file = "docker-build-#{service_name}.log"
+  quiet = ENV["VERBOSE"] ? "" : " > /dev/null"
+  system("docker-compose up --build --exit-code-from #{service_name} #{service_name} 2>&1 | tee #{build_log_file}#{quiet}")
+  build_log_file # Returning the log file path for reference
+end
+
+# Helper method to extract test results from container logs
+def docker_compose_results(service_name)
+  `docker-compose logs #{service_name} 2>&1`
+end
+
+# Helper method to stop and remove containers quietly
+def docker_compose_down(service_name)
+  system("docker-compose stop #{service_name} > /dev/null 2>&1")
+  system("docker-compose rm -f #{service_name} > /dev/null 2>&1")
+end
+
+desc "Run tests across all Ruby versions in Docker"
+task "test:all" do
+  ruby_versions = [
+    "1.9.3", "2.0", "2.1.10", "2.2.10", "2.3.8", "2.4.10", "2.5.9", "2.6", "2.7.5", "3.0", "3.1", "3.2", "3.3-rc"
+  ]
+  threads = []
+
+  # Generate docker-compose.yml configuration
+  services = ruby_versions.each_with_object({}) do |version, hash|
+    normalized_name = "ruby_#{normalize_version(version)}"
+    hash[normalized_name] = {
+      "build" => {
+        "context" => ".",
+        "args" => {
+          "RUBY_VERSION" => version
+        }
+      },
+      "volumes" => [".:/usr/src/app"],
+      "command" => "rake"
+    }
+  end
+
+  # Write configuration to docker-compose.yml
+  File.open("docker-compose.yml", "w") { |file| file.write({ "version" => "3.8", "services" => services }.to_yaml) }
+
+  # Run tests in parallel
+  ruby_versions.each do |version|
+    threads << Thread.new do
+      service_name = "ruby_#{normalize_version(version)}"
+      docker_compose_up(service_name)
+      output = docker_compose_results(service_name)
+
+      if output.include?(", 0 failures, 0 errors")
+        puts "Ruby #{version}: ✅ passed"
+      else
+        puts "Ruby #{version} ❌ failed, run this version using `rake \"test:one[#{version}]\"`"
+      end
+
+      docker_compose_down(service_name)
+    end
+  end
+
+  # Wait for all threads to complete
+  threads.each(&:join)
+end
+
+desc "Run tests for a single Ruby version in Docker"
+task "test:one", [:version] do |t, args|
+  version = args[:version] || ENV["VERSION"]
+  raise ArgumentError, "You must specify a Ruby version." unless version
+  service_name = "ruby_#{normalize_version(version)}"
+
+  # Run the container in detached mode
+  build_log_file = docker_compose_up(service_name)
+
+  # Now we can use docker compose to wait for the service to finish
+  system("docker compose up --exit-code-from #{service_name}")
+  system("docker compose logs #{service_name}")
+
+  if ENV["VERBOSE"]
+    puts "Docker build logs for #{service_name}:"
+    puts File.read(build_log_file)
+  end
+
+  # Stop and remove the container
+  docker_compose_down(service_name)
+end
+
 
 task :default => :test

--- a/oas_agent.gemspec
+++ b/oas_agent.gemspec
@@ -33,4 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "nokogiri", "~> 1.12.0"
 end


### PR DESCRIPTION
# Testing ye olde Ruby versions locally in Docker

This will allow testing of failures on older Ruby versions locally as long as Docker is installed. To test all versions this library supports you can run:

    rake test:all

You will get an output something like this:

    Ruby 2.3.8 ❌ failed, run this version using `rake "test:one[2.3.8]"`
    Ruby 1.9.3 ❌ failed, run this version using `rake "test:one[1.9.3]"`
    Ruby 2.2.10 ❌ failed, run this version using `rake "test:one[2.2.10]"`
    Ruby 2.4.10 ❌ failed, run this version using `rake "test:one[2.4.10]"`
    Ruby 3.0: ✅ passed
    Ruby 3.1: ✅ passed
    Ruby 2.7.5: ✅ passed
    Ruby 3.2: ✅ passed
    Ruby 3.3-rc: ✅ passed
    Ruby 2.6: ✅ passed
    Ruby 2.5.9: ✅ passed
    Ruby 2.1.10 ❌ failed, run this version using `rake "test:one[2.1.10]"`
    Ruby 2.0 ❌ failed, run this version using `rake "test:one[2.0]"`

Where a version fails you will be given a command to run the tests for that specific version:

    rake "test:one[2.4.10]"
    or…
    VERSION=2.4.10 rake test:one

This will give you the test suite output too so you can see what failed. If you need to diagnose Docker/build issues then pass VERBOSE to get the docker build output:

    VERBOSE=1 rake "test:one[2.4.10]"

If you need to further diagnose Docker build issues you can build a docker image for the version you're interested in directly:

    docker build . --build-arg RUBY_VERSION=2.4.10