### PR TITLE
Consolidate kwargs messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ After checking out the repo, run `bin/setup` to install dependencies. Then, run 
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
+### Running one test
+
+    ruby -Itest test/lib/agent/ruby_receiver_test.rb
+
 ### Testing ye olde Ruby versions in Docker
 
 You can test old versions of Ruby locally as long as you have Docker installed. To test all versions this library supports you can run:

--- a/lib/agent/agent.rb
+++ b/lib/agent/agent.rb
@@ -36,8 +36,8 @@ module OasAgent
 
       def start
         @reporter = Reporter.instance
-        @receiver = Receiver.new(reporter: @reporter)
-        @ruby_receiver = RubyReceiver.new(reporter: @reporter)
+        @receiver = Receiver.new(reporter: @reporter, root: Rails.root.expand_path.to_s)
+        @ruby_receiver = RubyReceiver.new(reporter: @reporter, root: Rails.root.expand_path.to_s)
       end
     end
   end

--- a/lib/agent/receiver.rb
+++ b/lib/agent/receiver.rb
@@ -6,9 +6,9 @@ require "agent/configuration/manager"
 module OasAgent
   module Agent
     class Receiver
-      def initialize(reporter:)
+      def initialize(reporter:, root:)
         @reporter = reporter
-        @rails_root = Rails.root.expand_path.to_s
+        @rails_root = root
         @rails_version = Rails::VERSION::STRING
       end
 

--- a/lib/agent/ruby_receiver.rb
+++ b/lib/agent/ruby_receiver.rb
@@ -7,9 +7,9 @@ require "singleton"
 module OasAgent
   module Agent
     class RubyReceiver
-      def initialize(reporter:)
+      def initialize(reporter:, root:)
         @reporter = reporter
-        @rails_root = Rails.root.expand_path.to_s
+        @rails_root = root
       end
 
       def push(message, callstack)

--- a/lib/agent/ruby_receiver.rb
+++ b/lib/agent/ruby_receiver.rb
@@ -16,7 +16,7 @@ module OasAgent
         message = {
           type: "ruby",
           version: RUBY_VERSION,
-          message: message.strip,
+          message: cleanup_ruby_kwargs_warning_message(message).strip,
           callstack: callstack.map(&:to_s)
         }
 
@@ -26,6 +26,19 @@ module OasAgent
       end
 
       private
+
+      # Ruby kwargs warnings include the file path and line number and this
+      # causes a new deprecation message to get created for each code location,
+      # so we remove the unique location from the message. We will get that data
+      # anyway in the callstack.
+      def cleanup_ruby_kwargs_warning_message(message)
+        kwargs_message = "Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call"
+        if message.end_with? kwargs_message
+          return kwargs_message
+        else
+          return message
+        end
+      end
 
       def config
         OasAgent::AgentContext.config

--- a/test/lib/agent/ruby_receiver_test.rb
+++ b/test/lib/agent/ruby_receiver_test.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "agent/agent"
+
+class OasAgentRubyReceiverTest < Minitest::Test
+  def test_strips_location_from_kwargs_message
+    fake_reporter = []
+    r = OasAgent::Agent::RubyReceiver.new(reporter: fake_reporter, root: "/a/b/c")
+    r.push("/home/runner/app/lib/resource_list.rb:100: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call", ["a", "b"])
+    assert_equal "Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call", fake_reporter.first[:message]
+  end
+
+  def test_leaves_non_kwargs_messages_unchanged
+    fake_reporter = []
+    r = OasAgent::Agent::RubyReceiver.new(reporter: fake_reporter, root: "/a/b/c")
+    r.push("/home/runner/app/lib/resource_list.rb:100: warning: Using the last argument as keyword parameters is OK, carry on", ["a", "b"])
+    assert_equal "/home/runner/app/lib/resource_list.rb:100: warning: Using the last argument as keyword parameters is OK, carry on", fake_reporter.first[:message]
+  end
+end


### PR DESCRIPTION
The location is contained in the callstack for Ruby kwargs deprectaion messages, and when it is included in the message it creates a new deprecation for each location which is confusing in the UI.