### PR TITLE
Update gemspec for older Rubies

### DIFF
--- a/oas_agent.gemspec
+++ b/oas_agent.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path("lib", __dir__)
+lib = File.expand_path("lib", File.dirname(__FILE__))
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "agent/version"
 

--- a/oas_agent.gemspec
+++ b/oas_agent.gemspec
@@ -12,11 +12,13 @@ Gem::Specification.new do |spec|
   spec.description   = %q{The Own & Ship ruby agent, reports deprecations and modernisation metrics to the Own & Ship web app}
   spec.homepage      = "https://github.com/wjessop/oas_agent"
 
-  spec.metadata["allowed_push_host"] = "https://rubygems.org"
+  if spec.respond_to?(:metadata)
+    spec.metadata["allowed_push_host"] = "https://rubygems.org"
 
-  spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "https://github.com/wjessop/oas_agent"
-  spec.metadata["changelog_uri"] = "https://github.com/wjessop/oas_agent/blob/master/CHANGELOG.md"
+    spec.metadata["homepage_uri"] = spec.homepage
+    spec.metadata["source_code_uri"] = "https://github.com/wjessop/oas_agent"
+    spec.metadata["changelog_uri"] = "https://github.com/wjessop/oas_agent/blob/master/CHANGELOG.md"
+  end
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
## What?

- [x] Swap `__dir__` for `File.dirname(__FILE__)` for Ruby < 2
- [x] Check `Gem::Specification#metadata` exists before setting it

## Why?

Ruby 2 introduced `__dir__` as a shorthand for directory-containing-current-file, so we can't use it in older rubies.

Rubygems 2 introduced the metadata method (exposed as `spec.metadata` in the gemspec), so if we try and use it on older rubygem versions it throws a `NoMethodError`. We can just check for the existence before setting those attributes.
