### PR TITLE
Updates to local ci mostly

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+# Disallow everything at first
+.*
+*
+# Now whitelist files we want in the test containers
+!/lib/
+!/test/
+!/Gemfile
+!/Rakefile
+!/oas_agent.gemspec

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,6 @@ RUN { \
 WORKDIR /usr/src/app
 COPY . .
 
-# We don't need rubocop installed in the container.
-RUN sed -i '/spec\.add_development_dependency "rubocop"/d' oas_agent.gemspec
-
 # Install bundler version compatible with older Ruby versions and install gems
 RUN if ruby -e 'exit RUBY_VERSION < "2.3"' ; then \
         gem install bundler -v1.17.3; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,10 @@ WORKDIR /usr/src/app
 COPY . .
 
 RUN rm -r Gemfile.lock .ruby-lsp .git .github .DS_Store
+# If we're removing the Gemfile.lock we may as well remove rubocop, it's
+# a dev dep and won't affect tests or production
+RUN sed -i '/spec\.add_development_dependency "rubocop"/d' oas_agent.gemspec
+
 # Install bundler version compatible with older Ruby versions and install gems
 RUN if ruby -e 'exit RUBY_VERSION < "2.6"'; then \
         gem install bundler -v '<= 2.3.26'; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,11 @@ RUN rm -r Gemfile.lock .ruby-lsp .git .github .DS_Store
 RUN sed -i '/spec\.add_development_dependency "rubocop"/d' oas_agent.gemspec
 
 # Install bundler version compatible with older Ruby versions and install gems
-RUN if ruby -e 'exit RUBY_VERSION < "2.6"'; then \
+RUN if ruby -e 'exit RUBY_VERSION < "2.3"' ; then \
+        gem install bundler -v1.17.3; \
+    elif ruby -e 'exit RUBY_VERSION < "2.4"' ; then \
+        gem install bundler -v '<= 2.3.26'; \
+    elif ruby -e 'exit RUBY_VERSION < "2.6"' ; then \
         gem install bundler -v '<= 2.3.26'; \
     else \
         gem install bundler -v "$(tail -n1 Gemfile.lock | tr -d ' ')"; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN { \
 WORKDIR /usr/src/app
 COPY . .
 
+RUN rm -r Gemfile.lock .ruby-lsp .git .github .DS_Store
 # Install bundler version compatible with older Ruby versions and install gems
 RUN if ruby -e 'exit RUBY_VERSION < "2.6"'; then \
         gem install bundler -v '<= 2.3.26'; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,7 @@ RUN { \
 WORKDIR /usr/src/app
 COPY . .
 
-RUN rm -r Gemfile.lock .ruby-lsp .git .github .DS_Store
-# If we're removing the Gemfile.lock we may as well remove rubocop, it's
-# a dev dep and won't affect tests or production
+# We don't need rubocop installed in the container.
 RUN sed -i '/spec\.add_development_dependency "rubocop"/d' oas_agent.gemspec
 
 # Install bundler version compatible with older Ruby versions and install gems
@@ -31,6 +29,6 @@ RUN if ruby -e 'exit RUBY_VERSION < "2.5"'; then \
         bundle config build.nokogiri "--use-system-libraries --with-xml2-include=/usr/local/opt/libxml2/include/libxml2"; \
     fi
 
-RUN bundle
+RUN bundle --without lint
 
 CMD ["bundle", "exec", "rake"]

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,12 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in oas_ruby_agent.gemspec
 gemspec
+
+# All other dependencies need to work with the earliest supported ruby
+# (vurrently 1.9.3) up to head as they are installed as part of the test run,
+# except rubocop which only needs to work on the version from .ruby-version as
+# that's the only version we do linting in, to do linting in other versions
+# would be redundant.
+group :lint do
+  gem "rubocop"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,7 +48,7 @@ PLATFORMS
   x86_64-darwin-22
 
 DEPENDENCIES
-  bundler (~> 2.0)
+  bundler
   minitest (~> 5.0)
   nokogiri
   oas_agent!

--- a/oas_agent.gemspec
+++ b/oas_agent.gemspec
@@ -33,7 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "msgpack", "< 1.4.2"
 
   # Development dependencies must be version specced to work from Ruby 1.9.3 up to Ruby head
-  spec.add_development_dependency "rubocop"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest", "~> 5.0"

--- a/oas_agent.gemspec
+++ b/oas_agent.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
 
   # Development dependencies must be version specced to work from Ruby 1.9.3 up to Ruby head
   spec.add_development_dependency "rubocop"
-  spec.add_development_dependency "bundler", "~> 2.0"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "nokogiri"


### PR DESCRIPTION
Most of this was done while trying to get 2.2 and 2.3 working, but doesn't feel directly related to those efforts so a separate PR.

Removes some files that aren't needed, including Gemfile.lock that prevents older versions of Ruby from working. Removes the bundler version from the gemspec for the same reasons. Removes rubocop when running tests locally in Docker, it's not needed so we don't need to install it.