### PR TITLE
If we pin msgpack we limit where the gem can be installed

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     oas_agent (0.0.1)
-      msgpack (< 1.4.2)
+      msgpack
 
 GEM
   remote: https://rubygems.org/
@@ -12,7 +12,7 @@ GEM
     language_server-protocol (3.17.0.3)
     mini_portile2 (2.6.1)
     minitest (5.13.0)
-    msgpack (1.3.3)
+    msgpack (1.7.2)
     nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
       racc (~> 1.4)

--- a/oas_agent.gemspec
+++ b/oas_agent.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   # Because we're asking clients to include this gem in their app with an
   # unknown Ruby version we can't pin the version here as it could conflict with
   # the environment the gem is runnign in.
-  spec.add_dependency "msgpack", "< 1.4.2"
+  spec.add_dependency "msgpack"
 
   # Development dependencies must be version specced to work from Ruby 1.9.3 up to Ruby head
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
We want clients to be able to specify their own msgpack version and pinning it might prevent that.